### PR TITLE
Added Tests For robotHasPossession And robotBeingPassedTo

### DIFF
--- a/src/software/ai/hl/stp/evaluation/robot_test.cpp
+++ b/src/software/ai/hl/stp/evaluation/robot_test.cpp
@@ -101,6 +101,19 @@ TEST(RobotEvaluationTest, has_possession_directly_in_front_of_robot)
     EXPECT_TRUE(Evaluation::robotHasPossession(ball, robot));
 }
 
+TEST(RobotEvaluationTest, has_possession_directly_in_front_of_robot_at_future_timestamp)
+{
+    Point ball_position  = Point(0.07, 0);
+    Vector ball_velocity = Vector(0, 0);
+    Timestamp timestamp  = Timestamp::fromSeconds(1);
+    Ball ball            = Ball(ball_position, ball_velocity, timestamp);
+
+    Robot robot = Robot(0, Point(0, 0), Vector(), Angle::zero(), AngularVelocity::zero(),
+                        timestamp);
+
+    EXPECT_TRUE(Evaluation::robotHasPossession(ball, robot));
+}
+
 TEST(RobotEvaluationTest, has_possession_ball_to_side_of_robot)
 {
     Point ball_position  = Point(0.07, 0);
@@ -184,6 +197,19 @@ TEST(RobotEvaluationTest, pass_with_ball_direct_fast)
     Point ball_position  = Point(0.035, 0.06);
     Vector ball_velocity = Vector(5, 5);
     Timestamp timestamp  = Timestamp::fromSeconds(0);
+    Ball ball            = Ball(ball_position, ball_velocity, timestamp);
+
+    Robot robot = Robot(0, Point(2.035, 2.06), Vector(), Angle::ofDegrees(59.74356),
+                        AngularVelocity::zero(), timestamp);
+
+    EXPECT_TRUE(Evaluation::robotBeingPassedTo(ball, robot));
+}
+
+TEST(RobotEvaluationTest, pass_with_ball_direct_fast_at_future_timestamp)
+{
+    Point ball_position  = Point(0.035, 0.06);
+    Vector ball_velocity = Vector(5, 5);
+    Timestamp timestamp  = Timestamp::fromSeconds(1);
     Ball ball            = Ball(ball_position, ball_velocity, timestamp);
 
     Robot robot = Robot(0, Point(2.035, 2.06), Vector(), Angle::ofDegrees(59.74356),


### PR DESCRIPTION
Added tests specifically for checking cases where we're asking for
information at a timestamp in the future

<!---
This file outlines a list of common things that should be addressed when opening a PR. It's built from previous issues we've seen in a lot of pull requests. If you notice something that's being noted in a lot of PR's, it should probably be added here to help save people time in the future.
-->

## Please fill out the following before requesting review on this PR

### Description

<!--
    Give a high-level description of the changes in this PR
-->

### Testing Done

<!--
    Outline any testing that was done for these changes. This could be unit tests, integration tests,etc.
-->

### Resolved Issues

<!--
    Link any issues that this PR resolved. Eg `resolves #1, #2, and #5` (note that they MUST be specified like this so Github can automatically close them then this PR merges)

    Please connect this PR to the issue in Zenhub by going to the bottom of this page and clicking "Connect With Issue" (so that this link is tracked in zenhub!)
-->

### Length Justification

<!-- If this pull request is longer then **500** lines (additions + deletions), please justify here why we *cannot* break this up into multiple pull requests. -->

### Review Checklist

<!--
    (Please check every item to indicate your code complies with it (by changing `[ ]`->`[x]`). This will hopefully save both you and the reviewer(s) a lot of time!)
-->

**_It is the reviewers responsibility to also make sure every item here has been covered_**

- [ ] **Function & Class comments**: All function definitions (usually in the `.h` file) should have a javadoc style comment at the start of them. For examples, see the functions defined in `thunderbots/software/geom`. Similarly, all classes should have an associated Javadoc comment explaining the purpose of the class.
- [ ] **Remove all commented out code**
- [ ] **Remove extra print statements**: for example, those just used for testing
- [ ] **Resolve all TODO's**: All `TODO` (or similar) statements should either be completed or associated with a github issue
- [ ] **Justify drops in code coverage**: If this PR results in a non-trivial drop in code coverage (a bot should post a coverage diagram as a comment), please justify why we can't test the code that's not covered.

<!--
    Feel free to make additions of things that we should be checking to this file if you think there's something missing!!!!
    At the same time, consider that adding things to this list increases the burden on everyone opening a pull request. 
    Perhaps there is a way we can automatically enforce whatever item you want to add?
-->
